### PR TITLE
Feat: habilitar link en sponsors y ajustar orden en botones de /talks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy PyDay to VPS
+on: [ push: { branches: [ main ] } ]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout código
+    - uses: actions/setup-node@v4
+      name: Setup Node.js 22.x
+      with:
+        node-version: '22.x'
+        cache: 'npm'
+    - name: Instalar dependencias y build
+      run: |
+        npm ci
+        npm run build
+    - name: Configure SSH
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        echo "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+      shell: bash
+    - name: Copiar artefactos al servidor
+      uses: appleboy/scp-action@v1
+      with:
+        host: ${{ secrets.VPS_HOST }}
+        username: ${{ secrets.VPS_USER }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        port: ${{ secrets.VPS_PORT }}
+        source: ".next/,public,next.config.js,package.json,package-lock.json"
+        target: ${{ secrets.TARGET_PATH }}
+    - name: Instalar PM2 y lanzar en VPS
+      uses: appleboy/ssh-action@v1
+      with:
+        host: ${{ secrets.VPS_HOST }}
+        username: ${{ secrets.VPS_USER }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        port: ${{ secrets.VPS_PORT }}
+        script: |
+          cd ${{ secrets.TARGET_PATH }}
+          npm install --omit=dev
+          pm2 delete pyday || true
+          pm2 start npm --name "pyday" -- run start
+          pm2 save

--- a/src/app/sitemap.xml/route.js
+++ b/src/app/sitemap.xml/route.js
@@ -1,49 +1,61 @@
-import cityData from "@/data/cities"; 
+import cityData from "@/data/cities";
 
-export const dynamic = 'force-static';
+export const dynamic = "force-static";
 export const revalidate = 3600;
 
 export async function GET() {
-  const baseUrl = (process.env.NEXT_PUBLIC_SITE_URL || "https://pyday.vercel.app").replace(/\/$/, '');
+  const baseUrl = (
+    process.env.NEXT_PUBLIC_SITE_URL || "https://pyday.cl"
+  ).replace(/\/$/, "");
 
   // Validación de datos
-  if (!cityData || typeof cityData !== 'object') {
-    throw new Error('Datos de ciudades no encontrados');
+  if (!cityData || typeof cityData !== "object") {
+    throw new Error("Datos de ciudades no encontrados");
   }
 
   // Generar URLs
   const urls = [
-    ...['', '/multimedia', '/previous', '/register', '/sponsors']
-      .map(path => ({
-        url: new URL(path, baseUrl).href,
-        lastModified: new Date().toISOString(),
-        priority: path === '' ? 1.0 : 0.8,
-      })),
-    ...Object.keys(cityData).map(citySlug => ({
+    ...[
+      "",
+      "/multimedia",
+      "/previous",
+      "/register",
+      "/sponsors",
+      "/conduct",
+      "/talks",
+    ].map((path) => ({
+      url: new URL(path, baseUrl).href,
+      lastModified: new Date().toISOString(),
+      priority: path === "" ? 1.0 : 0.8,
+    })),
+    ...Object.keys(cityData).map((citySlug) => ({
       url: new URL(`/${citySlug}`, baseUrl).href,
       lastModified: new Date().toISOString(),
       priority: 0.9,
-    }))
+    })),
   ];
-
 
   // Generar XML
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    ${urls.map(({ url, lastModified, priority }) => `
+    ${urls
+      .map(
+        ({ url, lastModified, priority }) => `
       <url>
         <loc>${url}</loc>
         <lastmod>${lastModified}</lastmod>
         <changefreq>weekly</changefreq>
         <priority>${priority}</priority>
       </url>
-    `).join('')}
+    `
+      )
+      .join("")}
     </urlset>`;
 
   return new Response(xml, {
     headers: {
-      'Content-Type': 'application/xml',
-      'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=3600'
+      "Content-Type": "application/xml",
+      "Cache-Control": "public, s-maxage=86400, stale-while-revalidate=3600",
     },
   });
 }

--- a/src/app/sponsors/components/SponsorList.js
+++ b/src/app/sponsors/components/SponsorList.js
@@ -6,7 +6,7 @@ import mockSponsors from "@/data/sponsors";
 
 export default function SponsorList() {
   const [sponsors, setSponsors] = useState([]);
-
+  
   useEffect(() => {
     setSponsors(mockSponsors);
     //TODO: Cuando se implemente Sanity:
@@ -30,9 +30,16 @@ export default function SponsorList() {
             Patrocinadores
           </span>
         </h2>
-        <p className="text-text-white">2024</p>
+        <p className="text-text-white">2025</p>
+        <motion.p 
+          className="mt-2 text-white bold italic"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.3 }}
+        >
+          Próximamente se anunciarán los patrocinadores oficiales de este año
+        </motion.p>
       </div>
-
       {/* Contenedor Principal */}
       <div
         className="max-w-6xl mx-auto bg-gradient-to-br from-[var(--primary-green)]/15 via-[var(--accent-yellow)]/10 to-[var(--outline-red)]/15
@@ -55,7 +62,6 @@ export default function SponsorList() {
           className="absolute inset-0 bg-[radial-gradient(circle_at_20%_80%,rgba(242,57,57,0.08),transparent_60%)]
             pointer-events-none rounded-3xl z-0"
         />
-
         {/* Grid de sponsors */}
         <div className="relative z-10 p-8 md:p-10 grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8 lg:gap-10">
           {sponsors.map((sponsor) => (
@@ -63,13 +69,17 @@ export default function SponsorList() {
               key={sponsor._id}
               src={sponsor.logo.asset.url}
               alt={sponsor.name}
-              className="group relative p-4 md:p-6 bg-gradient-to-br from-[var(--primary-green)]/8 via-[var(--accent-yellow)]/5 to-[var(--primary-green)]/8 
-        backdrop-blur-lg rounded-2xl transition-all duration-500 hover:duration-300
-        hover:shadow-[0_0_40px_-10px_rgba(61,139,55,0.4)]
-        border-2 border-[var(--primary-green)]/20 hover:border-[var(--accent-yellow)]/40
-        transform-gpu hover:-translate-y-2 cursor-pointer"
+              url={sponsor.url || ""} 
+              className="group relative p-4 md:p-6 bg-gradient-to-br from-[var(--primary-green)]/8 via-[var(--accent-yellow)]/5 to-[var(--primary-green)]/8
+                backdrop-blur-lg rounded-2xl transition-all duration-500 hover:duration-300
+                hover:shadow-[0_0_40px_-10px_rgba(61,139,55,0.4)]
+                border-2 border-[var(--primary-green)]/20 hover:border-[var(--accent-yellow)]/40
+                transform-gpu hover:-translate-y-2 cursor-pointer"
             />
           ))}
+        </div>
+        <div className="text-center p-4 text-sm text-[var(--text-white)]/70 italic">
+          Patrocinadores 2024
         </div>
       </div>
     </motion.section>

--- a/src/app/sponsors/components/SponsorList.js
+++ b/src/app/sponsors/components/SponsorList.js
@@ -2,20 +2,16 @@
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import SponsorLogo from "@/app/sponsors/components/SponsorLogo";
-import mockSponsors from "@/data/sponsors";
+import sponsorsData from "@/data/sponsors";
 
 export default function SponsorList() {
   const [sponsors, setSponsors] = useState([]);
   
   useEffect(() => {
-    setSponsors(mockSponsors);
-    //TODO: Cuando se implemente Sanity:
-    // const fetchSponsors = async () => {
-    //   const data = await client.fetch('*[_type == "sponsor"] | order(level asc)');
-    //   setSponsors(data);
-    // };
-    // fetchSponsors();
+    setSponsors(sponsorsData);
   }, []);
+
+  const hasSponsors = sponsors.length > 0;
 
   return (
     <motion.section
@@ -31,57 +27,51 @@ export default function SponsorList() {
           </span>
         </h2>
         <p className="text-text-white">2025</p>
-        <motion.p 
-          className="mt-2 text-white bold italic"
+      </div>
+
+      {hasSponsors ? (
+        <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          transition={{ delay: 0.3 }}
+          className="max-w-6xl mx-auto bg-gradient-to-br from-[var(--primary-green)]/15 via-[var(--accent-yellow)]/10 to-[var(--outline-red)]/15
+            backdrop-blur-md rounded-3xl border border-[var(--primary-green)]/30
+            shadow-[0_0_80px_-15px_rgba(61,139,55,0.35)] hover:shadow-[0_0_100px_-20px_rgba(61,139,55,0.45)]
+            transition-shadow duration-500"
         >
-          Próximamente se anunciarán los patrocinadores oficiales de este año
-        </motion.p>
-      </div>
-      {/* Contenedor Principal */}
-      <div
-        className="max-w-6xl mx-auto bg-gradient-to-br from-[var(--primary-green)]/15 via-[var(--accent-yellow)]/10 to-[var(--outline-red)]/15
-          backdrop-blur-md rounded-3xl
-          border border-[var(--primary-green)]/30
-          shadow-[0_0_80px_-15px_rgba(61,139,55,0.35)]
-          transform-gpu hover:shadow-[0_0_100px_-20px_rgba(61,139,55,0.45)]
-          transition-shadow duration-500"
-      >
-        {/* Capas de luminosidad dinámica */}
-        <div
-          className="absolute inset-0 bg-[radial-gradient(circle_at_30%_30%,rgba(255,225,65,0.15),transparent_70%)]
-            pointer-events-none rounded-3xl z-0"
-        />
-        <div
-          className="absolute inset-0 bg-[radial-gradient(circle_at_70%_70%,rgba(61,139,55,0.15),transparent_70%)]
-            pointer-events-none rounded-3xl z-0"
-        />
-        <div
-          className="absolute inset-0 bg-[radial-gradient(circle_at_20%_80%,rgba(242,57,57,0.08),transparent_60%)]
-            pointer-events-none rounded-3xl z-0"
-        />
-        {/* Grid de sponsors */}
-        <div className="relative z-10 p-8 md:p-10 grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8 lg:gap-10">
-          {sponsors.map((sponsor) => (
-            <SponsorLogo
-              key={sponsor._id}
-              src={sponsor.logo.asset.url}
-              alt={sponsor.name}
-              url={sponsor.url || ""} 
-              className="group relative p-4 md:p-6 bg-gradient-to-br from-[var(--primary-green)]/8 via-[var(--accent-yellow)]/5 to-[var(--primary-green)]/8
-                backdrop-blur-lg rounded-2xl transition-all duration-500 hover:duration-300
-                hover:shadow-[0_0_40px_-10px_rgba(61,139,55,0.4)]
-                border-2 border-[var(--primary-green)]/20 hover:border-[var(--accent-yellow)]/40
-                transform-gpu hover:-translate-y-2 cursor-pointer"
-            />
-          ))}
-        </div>
-        <div className="text-center p-4 text-sm text-[var(--text-white)]/70 italic">
-          Patrocinadores 2024
-        </div>
-      </div>
+          {/* Capas de luminosidad */}
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_30%,rgba(255,225,65,0.15),transparent_70%)] rounded-3xl z-0" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_70%_70%,rgba(61,139,55,0.15),transparent_70%)] rounded-3xl z-0" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_80%,rgba(242,57,57,0.08),transparent_60%)] rounded-3xl z-0" />
+
+          {/* Grid de sponsors */}
+          <div className="relative z-10 p-8 md:p-10 grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8 lg:gap-10">
+            {sponsors.map((sponsor) => (
+              <SponsorLogo
+                key={sponsor._id}
+                src={sponsor.logo.asset.url}
+                alt={sponsor.name}
+                url={sponsor.url || ""}
+                className="group relative p-4 md:p-6 bg-gradient-to-br from-[var(--primary-green)]/8 via-[var(--accent-yellow)]/5 to-[var(--primary-green)]/8
+                  backdrop-blur-lg rounded-2xl transition-all duration-500 hover:duration-300
+                  hover:shadow-[0_0_40px_-10px_rgba(61,139,55,0.4)]
+                  border-2 border-[var(--primary-green)]/20 hover:border-[var(--accent-yellow)]/40
+                  transform-gpu hover:-translate-y-2 cursor-pointer"
+              />
+            ))}
+          </div>
+        </motion.div>
+      ) : (
+        <motion.div
+          initial={{ opacity: 0, scale: 0.9 }}
+          animate={{ opacity: 1, scale: 1 }}
+          className="text-center py-12"
+        >
+          <p className="text-xl md:text-2xl text-[var(--accent-yellow)] italic font-semibold">
+            ¡Próximamente anunciaremos a nuestros patrocinadores!
+          </p>
+          <div className="mt-4 h-1 w-24 mx-auto bg-[var(--primary-green)]/40 rounded-full" />
+        </motion.div>
+      )}
     </motion.section>
   );
 }

--- a/src/app/sponsors/components/SponsorLogo.js
+++ b/src/app/sponsors/components/SponsorLogo.js
@@ -1,18 +1,21 @@
 "use client";
 import { motion } from "framer-motion";
 import Image from "next/image";
+import Link from "next/link";
 
-export default function SponsorLogo({ src, alt, className }) {
-  return (
+export default function SponsorLogo({ src, alt, className, url }) {
+  const content = (
     <motion.div
       className={className}
       whileHover={{ scale: 1.05 }}
       transition={{ type: "spring", stiffness: 300, damping: 20 }}
     >
       {/* Hover: Efecto de resplandor */}
-      <div className="absolute inset-0 bg-gradient-to-r from-[var(--primary-green)]/10 via-[var(--accent-yellow)]/15 to-[var(--primary-green)]/10 
-        rounded-2xl opacity-0 group-hover:opacity-40 transition-opacity duration-300 z-0" />
-      
+      <div
+        className="absolute inset-0 bg-gradient-to-r from-[var(--primary-green)]/10 via-[var(--accent-yellow)]/15 to-[var(--primary-green)]/10
+        rounded-2xl opacity-0 group-hover:opacity-40 transition-opacity duration-300 z-0"
+      />
+
       {/* Contenedor de imagen */}
       <div className="relative z-10 p-2">
         <Image
@@ -31,20 +34,30 @@ export default function SponsorLogo({ src, alt, className }) {
           }}
         />
       </div>
-      
+
       {/* Halo sutil alrededor del logo */}
-      <div className="absolute inset-0 -z-10 opacity-0 group-hover:opacity-20 transition-all duration-300
-        bg-[radial-gradient(circle_at_center,var(--accent-yellow),transparent_70%)]" />
-      
+      <div
+        className="absolute inset-0 -z-10 opacity-0 group-hover:opacity-20 transition-all duration-300
+        bg-[radial-gradient(circle_at_center,var(--accent-yellow),transparent_70%)]"
+      />
+
       {/* Efecto de partículas sutil */}
       <div
         className="absolute inset-0 opacity-10 group-hover:opacity-20
           transition-opacity duration-500 pointer-events-none rounded-2xl z-0"
       >
-        <div
-          className="absolute w-full h-full mix-blend-overlay opacity-40 rounded-2xl"
-        />
+        <div className="absolute w-full h-full mix-blend-overlay opacity-40 rounded-2xl" />
       </div>
     </motion.div>
   );
+
+  if (url && url !== "") {
+    return (
+      <Link href={url} target="_blank" rel="noopener noreferrer">
+        {content}
+      </Link>
+    );
+  }
+
+  return content;
 }

--- a/src/app/talks/page.js
+++ b/src/app/talks/page.js
@@ -94,7 +94,7 @@ export default function TalksPage() {
                   : "text-py-text"
               }`}
             >
-              {city.date.split(",")[0]} - {city.name}
+              {city.name} - {city.date.split(",")[0]}
             </button>
           ))}
         </div>

--- a/src/data/cities.js
+++ b/src/data/cities.js
@@ -3,7 +3,7 @@ import allTalks from "./talks";
 const cityData = {
   copiapo: {
     name: "Copiapó",
-    date: "Fecha por confirmar.",
+    date: "Fecha por confirmar",
     slug: "copiapo",
     mapCoords: { x: 50, y: 90 },
     venue: "Inacap sede Copiapó",

--- a/src/data/sponsors.js
+++ b/src/data/sponsors.js
@@ -4,11 +4,13 @@ const sponsors = [
     _id: 1,
     logo: { asset: { url: "/images/sponsors/psf.webp" } },
     name: "Python Software Foundation",
+    url: "https://www.python.org/psf/",
   },
   {
     _id: 2,
     logo: { asset: { url: "/images/sponsors/aws.webp" } },
     name: "Amazon Web Services",
+    url: "",
   },
 ];
 

--- a/src/data/sponsors.js
+++ b/src/data/sponsors.js
@@ -1,17 +1,39 @@
-// Ejemplo sponsors 2024:
+// GUÍA DE USO:
+// 1. Imágenes: Guardar en /public/images/sponsors/ como .webp (ej: "microsoft.webp")
+// 2. Data: Seguir el formato de objetos JSON como en los ejemplos
+// 3. Para comenzar, DEJA EL ARRAY VACÍO (sponsors = [])
+
 const sponsors = [
+  /*
+  // ▼▼▼ EJEMPLOS (BORRAR ESTO AL IMPLEMENTAR) ▼▼▼
   {
-    _id: 1,
-    logo: { asset: { url: "/images/sponsors/psf.webp" } },
+    _id: 1, // ID único (usar números consecutivos)
     name: "Python Software Foundation",
-    url: "https://www.python.org/psf/",
+    url: "https://www.python.org/psf/", // Enlace opcional
+    logo: { 
+      asset: { 
+        url: "/images/sponsors/psf.webp" // Ruta desde /public
+      } 
+    }
   },
   {
     _id: 2,
-    logo: { asset: { url: "/images/sponsors/aws.webp" } },
-    name: "Amazon Web Services",
-    url: "",
+    name: "Microsoft",
+    url: "https://microsoft.com",
+    logo: { 
+      asset: { 
+        url: "/images/sponsors/microsoft.webp" 
+      } 
+    }
   },
+  // ▲▲▲ EJEMPLOS ▲▲▲
+  */
 ];
+
+// ▼▼▼ IMPLEMENTACIÓN REAL (DESBLOQUEAR CUANDO HAYA PATROCINADORES) ▼▼▼
+// const sponsors = [
+//   // Añadir patrocinadores reales aquí
+// ];
+// ▲▲▲ IMPLEMENTACIÓN REAL ▲▲▲
 
 export default sponsors;


### PR DESCRIPTION
Este PR resuelve los siguientes issues:

- **Issue #1:** Se borró data, dejando indicaciones y ejemplo. Se agregó un _disclaimer_.
- **Issue #2:** Se modificó la data de **sponsors** para permitir la incorporación de un enlace en Next.js, el cual se habilitará una vez confirmados los sponsors 2025.
- **Issue #3:** Se ajustó el texto de los botones en la sección **/talks** para que se muestre primero el nombre de la ciudad y luego la fecha.

Closes #1  
Closes #2
Closes #3

![imagen](https://github.com/user-attachments/assets/0b1c654f-22a2-4198-9e8d-7c89543772a1)


Además, aprovechéde incorporar deploy.yml.

Para que el workflow de despliegue funcione correctamente, por favor añade lo siguiente en
 **Settings > Secrets and variables >Actions**:

**Secrets**:
1. **SSH\_PRIVATE\_KEY** – clave privada SSH (contenido de `gh_rsa`) para autenticarte sin contraseña [Stack Overflow](https://stackoverflow.com/questions/57685065/how-to-set-secrets-in-github-actions?utm_source=chatgpt.com).

 2. **SSH\_KNOWN\_HOSTS** – salida de `ssh-keyscan -p ${{ secrets.VPS_PORT }} ${{ secrets.VPS_HOST }}` para verificar la huella del servidor.

3. **VPS\_HOST** – IP o dominio de la VPS donde desplegamos.

4. **VPS\_USER** – usuario SSH en la VPS (por ejemplo `pyday`).

5. **VPS\_PORT** – puerto SSH (normalmente `22`, o el que use el servidor).

6. **TARGET\_PATH** – ruta remota donde copiar los ficheros (e.g. `/home/pyday`).

 **Nota:** necesitas privilegios de administrador para ver/crear estos secrets en el repositorio. Esos permisos los tiene @pablolirag y yo.

**Variables**:

Ya incorporé las vars no sensibles en variables de repositorio:

 * `NEXT_PUBLIC_SITE_URL` – URL pública del sitio. 
 * `NEXT_PUBLIC_FEATURE_REGISTRATION` – `"false"` o `"true"` para activar/desactivar registro de usuarios.
 * `NEXT_PUBLIC_FEATURE_SPONSORS` – `"false"` o `"true"` para sección de patrocinadores. 
 * `NEXT_PUBLIC_FEATURE_SPONSOR_FORM` – `"false"` o `"true"` para el formulario de patrocinio.
