### PR TITLE
fix: fixed 'Back' button in Hero section on mobile devices

### DIFF
--- a/src/components/HeroSection.js
+++ b/src/components/HeroSection.js
@@ -21,7 +21,7 @@ export default function HeroSection({
     >
       {/* Botón de regreso parte superior */}
       {backButton && (
-        <div className="absolute top-4 left-4 z-10">
+        <div className="absolute top-4 left-4 z-50 sm:top-4 sm:left-4 xs:top-6 xs:left-2">
           <Link
             href="/"
             className="flex items-center space-x-2 bg-black/50 backdrop-blur px-4 py-2 rounded-full text-white hover:bg-black/70 transition"
@@ -61,7 +61,7 @@ export default function HeroSection({
       )}
 
       {/* Contenido principal */}
-      <div className="relative z-10 w-full max-w-4xl mx-auto py-8 flex flex-col items-center justify-center">
+      <div className="relative z-10 w-full max-w-4xl mx-auto py-20 flex flex-col items-center justify-center">
         {/* Título */}
         {title && (
           <div className="mb-4">


### PR DESCRIPTION
Arregle el problema del botón volver  que quedaba queda detrás del texto e inactivo en dispositivos móviles en la página de ciudades del PyDay. 
![imagen](https://github.com/user-attachments/assets/280f65c8-ff86-4983-b12d-dd4606798c27)

![imagen](https://github.com/user-attachments/assets/8a0d6dfc-8248-41b5-b0e2-a1b816694c61)
