### PR TITLE
Fix: Titulo boton comunidad y bg boton ticket

### DIFF
--- a/src/app/[city]/page.js
+++ b/src/app/[city]/page.js
@@ -118,9 +118,11 @@ export default async function CityPage({ params }) {
 
       {/* Registro Section */}
       <section id="registro" className="container-py">
-        <FeatureGuard featureName="registration" cityData={data}>
-            <RegistrationForm />
-        </FeatureGuard>
+        <div className="bg-black/20 backdrop-blur rounded-lg p-6 md:p-8">
+          <FeatureGuard featureName="registration" cityData={data}>
+              <RegistrationForm />
+          </FeatureGuard>
+        </div>
       </section>
 
       {/* Agenda*/}
@@ -214,7 +216,7 @@ export default async function CityPage({ params }) {
       <FAQSection faqs={generalFAQs} />
 
       <CTAFinal
-        title={`¡Únete a la comunidad Python en ${data.name}!`}
+        title={`¡Únete al voluntariado de la comunidad Python Chile!`}
         subtitle="Aprende, comparte y conecta con desarrolladores y entusiastas de Python de toda la región y de Chile."
         buttonText="Registrarme ahora"
         href="https://docs.google.com/forms/d/e/1FAIpQLSdhHlnqwmYffl6JNzbAZ4IRRyM_8fcOB1QH0hyz6Vwi3VFOwg/viewform"


### PR DESCRIPTION
## 🧙  Issue relacionada #18 de caracter _urgente_.

## ⚠️  Problema detectado: 

Se ha detectado comprensión errónea de personas que quieren ticket para asistir a la PyDay de cierta sede pero se registran en el formulario de entrar como voluntariado, provocando entrevistas equívocas.

---

###  Corrección de título de la sección unirse a la comunidad Python Chile de la vista de sedes (al final):

#### Actual:
![image](https://github.com/user-attachments/assets/85e86dd6-4fad-41b7-a78e-1273fa17171d)

#### Corrección:
![image](https://github.com/user-attachments/assets/a7d5f5f6-fc0f-4f50-b27d-6accb9c7d562)

---

###  Background para la sección de obtener ticket de la vista de sedes:

#### Actual:
![image](https://github.com/user-attachments/assets/2d0df32f-097b-4443-abf9-ad5f4de5565a)


#### Corrección:
![image](https://github.com/user-attachments/assets/898cf002-0490-4325-b390-680becf1ef9c)


Quedo atento a cualquier comentario. Gracias!
