### PR TITLE
Fix select color style

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "init": "npm run build && npm run start",
     "dev": "next dev --turbopack",
     "build": "next build",
     "export": "next export",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -119,15 +119,8 @@ body {
 
   .select-theme option {
     background-color: var(--primary-green);
-    color: var(--primary-green) !important;
-    border: var(--primary-green) !important;
-    transition: background-color 0.2s ease, color 0.2s ease;
-  }
-
-  .select-theme option:hover,
-  .select-theme option:checked {
-    background-color: rgba(var(--accent-yellow) 0.3) !important;
     color: var(--text-white) !important;
+    border: var(--primary-green) !important;
   }
 
   /* Tarjetas de sponsors con colores de marca */


### PR DESCRIPTION
## Resumen Issue #16 🧙‍♂️

Corregí el estilo del elemento `select`, ahora se puede visualizar las opciones. Lo dejé simple manteniendo los colores.

## Captura:

### Antes de fix:
![image](https://github.com/user-attachments/assets/ae524590-e788-4370-9bf8-defd0a501821)


### Después de fix:
![image](https://github.com/user-attachments/assets/c486dc1e-f0be-487b-a0f2-2fac457d66f9)

## Cambios:

### Archivo globals.css

- Se eliminaron propiedades `hover` & `checked` porque no aportaban en la experiencia, por defecto el color background de `hover` es gris, y `checked` no aporta en distinguir qué opción del `select` es seleccionado, este ya se visualiza al principio. 

### Archivo jsconfig.js 

- Agregué un script `init` el cual ejecuta el `build` y `start`. Por temas de comodidad y no andar ejecutando dos comandos para levantar la app. Aclaro que este script no se utiliza en ningún lado del proyecto o pipeline.