### PR TITLE
Charla valpo reemplazo

### DIFF
--- a/src/data/sponsors.js
+++ b/src/data/sponsors.js
@@ -112,7 +112,7 @@ const communities = [
   {
     _id: 9,
     name: "Niñas PRO",
-    url: "https://wwww.ninaspro.cl",
+    url: "https://www.ninaspro.cl",
     logo: {
       asset: {
         url: "/images/sponsors/ninaspro_logo.webp"

--- a/src/data/talks.js
+++ b/src/data/talks.js
@@ -408,20 +408,20 @@ const allTalks = [
     id: 23,
     city: "valparaiso",
     type: "charla",
-    title: "Del caos al orden: cómo usamos Python para sincronizar el ecommerce y sobrevivir el camino",
-    description: "Cómo creamos Omaflow con Python: de planillas caóticas a una plataforma que conecta ecommerce con couriers y automatiza miles de órdenes. Una historia real de errores, aciertos y creatividad para resolver problemas con código.",
+    title: "Rust + Python = Poder Ilimitado: Introducción a PyO3",
+    description: "¿Velocidad de Rust con la flexibilidad de Python? En esta charla veremos cómo unir ambos mundos con PyO3, creando módulos Rust accesibles desde Python. Compartiré mi experiencia optimizando tareas críticas y los aprendizajes de este proceso.",
     time: "14:30 - 15:00",
     room: "Salón A101",
     speaker: {
-      name: "Marcelo Cavieres",
-      image: "/images/speakers/Marcelo_Cavieres.webp",
+      name: "Daniel Hernandez",
+      image: "/images/speakers/Daniel_Hernandez.webp",
       socials: {
-        linkedin: ""
+        linkedin: "https://www.linkedin.com/in/dhernandezmen/"
       }
     },
-    category: "caso-de-exito",
+    category: "tecnica",
     level: "intermedio",
-    tags: ["Python", "Emprendimiento", "Automatización", "Ecommerce", "DevOps"]
+    tags: ["Python", "Rust", "Optimización", "Desarrollo"]
   },
   {
     id: 24,


### PR DESCRIPTION
# Issue #23 

---

### Cambios:
- Charla `Marcelo Cavieres` reemplazado por charla de `Daniel Hernández` (Misma que stgo). Se cambian sólo datos propios de la charla, título, descripción, charlitas, entre otros. No hay cambio ni de **hora** ni de **sala**
- Enlace comunidad niñas pro se elimina caracter `w` que estaba sobrando.

---

### Antes:

#### Enlace niñas pro
![image](https://github.com/user-attachments/assets/1afeb4e3-ef1c-4790-969f-a4bf0b765232)

#### Charla
![image](https://github.com/user-attachments/assets/de72c6ac-6e73-440d-9b70-0725e6389b17)



### Ahora:

#### Enlace niñas pro
![image](https://github.com/user-attachments/assets/466703b3-2e29-4b11-8bac-2f0249d83dc4)

#### Charla
![image](https://github.com/user-attachments/assets/72eac61b-56d8-4c39-b223-165d5a981c2f)