### PR TITLE
Change 25 add access points valparaiso

### DIFF
--- a/src/app/[city]/page.js
+++ b/src/app/[city]/page.js
@@ -187,7 +187,36 @@ export default async function CityPage({ params }) {
             <p className="text-base md:text-lg font-medium mb-2">
               {data.address}
             </p>
-
+          {/* Mostrar solo si hay puntos de acceso definidos en la ciudad */}
+            {data.accessPoints && data.accessPoints.length > 0 && (
+              <>
+                <h3 className="text-lg md:text-xl font-semibold mt-4 mb-2">
+                  Puertas de acceso:
+                </h3>
+                <ul className="space-y-2">
+                  {data.accessPoints.map((entry, index) => (
+                    <li key={index} className="flex items-start space-x-2">
+                      {/* Icono de entrada */}
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="h-5 w-5 mt-0.5 text-blue-400 flex-shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M12 11c0 .5304-.2107 1.0391-.5858 1.4142C11.0391 12.7893 10.5304 13 10 13s-1.0391-.2107-1.4142-.5858C8.2107 12.0391 8 11.5304 8 11s.2107-1.0391.5858-1.4142C9.0391 9.2107 9.5304 9 10 9s1.0391.2107 1.4142.5858C11.7893 9.9609 12 10.4696 12 11z"
+                        />
+                      </svg>
+                      <span className="text-sm md:text-base">{entry}</span>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
             <h3 className="text-lg md:text-xl font-semibold mt-3 md:mt-4 mb-2">
               Opciones de transporte:
             </h3>

--- a/src/data/cities.js
+++ b/src/data/cities.js
@@ -43,6 +43,11 @@ const cityData = {
       "Metro Valparaíso: Estación Portales (10 min caminando)",
       "Micros 105, 106, 202, 215, 216",
     ],
+    accessPoints: [
+    "Entrada superior: Avenida Placeres",
+    "Entrada inferior: Avenida España",
+    "Entrada lateral: Calle Valdés"
+    ],
     introduction: {
       title: "¡Aventúrate en el Mundo de Python en PyDay Valparaíso!",
       description: "Únete a la cuarta edición de este emocionante evento en la Casa Central de la Universidad Técnica Federico Santa María. Disfruta de talleres interactivos y charlas inspiradoras en un ambiente creativo y colaborativo. PyDay Valparaíso 2025 es tu oportunidad para conectar con otros entusiastas, expandir conocimientos y explorar las posibilidades de este poderoso lenguaje de programación.",

--- a/src/data/talks.js
+++ b/src/data/talks.js
@@ -402,7 +402,7 @@ const allTalks = [
     },
     category: "tecnica",
     level: "intermedio",
-    tags: ["Python", "IA", "Automatización", "Open Source", "MCP", "n8n"]
+    tags: ["Python", "IA", "Automatización", "Open Source", "MCP", "N8N"]
   },
   {
     id: 23,
@@ -466,7 +466,7 @@ const allTalks = [
     id: 27,
     city: "valparaiso",
     type: "break",
-    title: "Coffee Break",
+    title: "Coffee Break - Cierre",
     description: "Espacio para compartir y despedirse de los asistentes.",
     time: "16:15 - 17:00",
     room: "Hall principal",


### PR DESCRIPTION
**Agregar puertas de acceso para Valparaíso en datos de ciudades y actualizar CityPage**

Este PR agrega la información de las puertas de acceso para la sede de Valparaíso en el archivo data/cities.js y actualiza el componente CityPage para mostrar condicionalmente la sección "Puertas de acceso" dentro de la sección de transporte existente.

**Cambios**
-Se añadieron los datos de las puertas de acceso para la sede de Valparaíso con las siguientes entradas:

1.         Entrada superior: Avenida Placeres
2.         Entrada inferior: Avenida España
3.         Entrada lateral: Calle Valdés

-Se actualizó CityPage para que la sección "Puertas de acceso" se muestre solo si la ciudad incluye el campo accessPoints.
-La sección de puertas de acceso está integrada dentro de la sección de transporte existente, mejorando la información para el usuario sin agregar componentes independientes nuevos.
-Además en data talks cambié el coffee break final le agregué cierre.

**Imagen**
![Sin título](https://github.com/user-attachments/assets/031a4749-5c6c-4c8c-9c74-f4443a50b3ab)

**Issue**

Closes #25