### PR TITLE
Fix 36 copy project

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix-36-copy-project
 
 jobs:
   deploy:
@@ -39,7 +40,7 @@ jobs:
         password: ${{ secrets.PYDAY_PASS }}
         port: ${{ secrets.PYDAY_PORT }}
         source: "out"
-        target: ""
+        target: "out"
 
     - name: Copia out a public
       uses: appleboy/ssh-action@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix-36-copy-project
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
         password: ${{ secrets.PYDAY_PASS }}
         port: ${{ secrets.PYDAY_PORT }}
         source: "out"
-        target: "out"
+        target: "."
 
     - name: Copia out a public
       uses: appleboy/ssh-action@v1


### PR DESCRIPTION
Hice pruebas ocupando esta misma rama (cambios removidos del deploy.yml) terminando bien el flujo. Los últimos 2 actions ejecutados corresponden a esto.

El target con path relativo no dio error 👍

La primera prueba lo hice con `target: "out"` por lo que se necesita eliminar esa carpeta en el servidor por favor.